### PR TITLE
Add README instructions and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 CarX contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
-# car_x
+# CarX Flutter Application
 
-A new Flutter project.
+CarX is a multi-role vehicle services application built with [Flutter](https://flutter.dev/). The project uses the [GetX](https://pub.dev/packages/get) package for state management and routing, and integrates Google Maps for location-based features.
 
-## Getting Started
+## Project Overview
 
-This project is a starting point for a Flutter application.
+The application includes several dashboards for different types of users (admin, manager, salesman, and workshop). Screens are provided for buying or selling cars, viewing companies, and locating workshops on a map. Assets and fonts are included to provide a full Arabic user interface.
 
-A few resources to get you started if this is your first Flutter project:
+## Setup
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+1. Install [Flutter](https://docs.flutter.dev/get-started/install) (Dart SDK `>=3.0.0 <4.0.0`).
+2. Clone this repository and change into the project directory:
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-# carx-flutter
+   ```bash
+   git clone <repository-url>
+   cd carx-flutter
+   ```
+
+3. Fetch project dependencies:
+
+   ```bash
+   flutter pub get
+   ```
+
+4. Connect a device or start an emulator and run the app:
+
+   ```bash
+   flutter run
+   ```
+
+## Usage
+
+After launching, sign up or log in to explore the various dashboards. Use the menus to navigate between features such as car management, workshop locations, and user account settings. The app demonstrates integration with Google Maps as well as a basic multi-user workflow.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document CarX Flutter project with setup and usage details
- add MIT open-source license

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68489287383c83219a575781b1a08d6e