### PR TITLE
Refactor signup connection for configurable API

### DIFF
--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -1,0 +1,3 @@
+class ApiConfig {
+  static const String baseUrl = String.fromEnvironment('API_BASE_URL', defaultValue: 'http://10.0.2.2:8000');
+}

--- a/lib/control/my_accountcontrol/accountcontroller.dart
+++ b/lib/control/my_accountcontrol/accountcontroller.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get/get.dart';
 import 'dart:convert';
@@ -17,7 +19,7 @@ class accountcontroller extends GetxController {
   Map users = {};
 
   profileco() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/me');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/me');
 
     var response =
         await http.get(url, headers: {'Authorization': 'Bearer ${token}'});

--- a/lib/control/view_company/view_companys.dart
+++ b/lib/control/view_company/view_companys.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -22,15 +24,15 @@ class viewcopmanycontroller extends GetxController {
   List data = [];
 
   Future<void> getallcompany() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Company/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Company/getAll');
 
     var response = await http.get(
       url,
     );
     var status = response.statusCode;
     data = jsonDecode(response.body);
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
 
     if (status == 200) {
     } else {}

--- a/lib/control/view_workshop/view_workshope_cont.dart
+++ b/lib/control/view_workshop/view_workshope_cont.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -17,15 +19,15 @@ class viewworkshopcontroller extends GetxController {
   var id;
   List data = [];
   Future<void> getallworkshop() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Workshop/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Workshop/getAll');
 
     var response = await http.get(
       url,
     );
     var status = response.statusCode;
     responce(response);
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
     update();
   }
 

--- a/lib/moudle/admin/add_car_comp.dart
+++ b/lib/moudle/admin/add_car_comp.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/control/companys/add_company_controller.dart';
@@ -10,7 +12,7 @@ Future<void> addcompanyconn() async {
   addcopanycontrol controller = Get.put(
     addcopanycontrol(),
   );
-  var url = Uri.parse('http://10.0.2.2:8000/api/Company/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Company/save');
   var response = await http.post(url, body: {
     'nameCompany': controller.compyname,
     'code': controller.code,
@@ -22,8 +24,8 @@ Future<void> addcompanyconn() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/add_comp_dierctor.dart
+++ b/lib/moudle/admin/add_comp_dierctor.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_company/view_companys.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -10,7 +12,7 @@ Future<void> addcompanydierctor() async {
   );
   var ids = controller.id;
   var url =
-      Uri.parse('http://10.0.2.2:8000/api/Company/setCompanyDirector/$ids');
+      Uri.parse('${ApiConfig.baseUrl}/api/Company/setCompanyDirector/$ids');
   var response = await http.post(url, body: {
     'name': controller.username,
     'mobile': controller.phonenumber,
@@ -20,8 +22,8 @@ Future<void> addcompanydierctor() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200 &&
       response.body.contains("This Company has a Company Director")) {
     Get.rawSnackbar(

--- a/lib/moudle/admin/add_workshop.dart
+++ b/lib/moudle/admin/add_workshop.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/worksope/workshope_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -9,7 +11,7 @@ Future<void> addworkeshopconn() async {
     workashopcontrol(),
   );
   var rate = 0;
-  var url = Uri.parse('http://10.0.2.2:8000/api/Workshop/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Workshop/save');
   var response = await http.post(url, body: {
     'nameWorkshop': controller.name_ar,
     'phone': controller.phone,
@@ -26,8 +28,8 @@ Future<void> addworkeshopconn() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
 
   if (status == 200) {
     Get.rawSnackbar(

--- a/lib/moudle/admin/delete_car_comp_director.dart
+++ b/lib/moudle/admin/delete_car_comp_director.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_company/view_companys.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -10,14 +12,14 @@ Future<void> deletecompconn() async {
   );
   var ids = controller.id;
   var url =
-      Uri.parse('http://10.0.2.2:8000/api/Company/deleteCompanyDirector/$ids');
+      Uri.parse('${ApiConfig.baseUrl}/api/Company/deleteCompanyDirector/$ids');
   var response = await http.delete(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 404) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/delete_workshope.dart
+++ b/lib/moudle/admin/delete_workshope.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_workshop/view_workshope_cont.dart';
 import 'package:car_x/theme/theme.dart';
 import 'package:flutter/material.dart';
@@ -11,14 +13,14 @@ Future<void> deleteworkshopconn() async {
     viewworkshopcontroller(),
   );
   var ids = controller.id;
-  var url = Uri.parse('http://10.0.2.2:8000/api/Workshop/delete/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Workshop/delete/$ids');
   var response = await http.delete(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/frezz.dart
+++ b/lib/moudle/admin/frezz.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_company/view_companys.dart';
 import 'package:flutter/material.dart';
 
@@ -10,14 +12,14 @@ viewcopmanycontroller controller = Get.put(
 );
 var ids = controller.id;
 Future<void> frezzcompconn() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Company/freeze/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Company/freeze/$ids');
   var response = await http.post(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/unfrezz.dart
+++ b/lib/moudle/admin/unfrezz.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_company/view_companys.dart';
 import 'package:flutter/material.dart';
 
@@ -10,14 +12,14 @@ viewcopmanycontroller controller = Get.put(
 );
 var ids = controller.id;
 Future<void> unfrezzcompconn() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Company/unfreezeBrand/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Company/unfreezeBrand/$ids');
   var response = await http.post(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/update_company.dart
+++ b/lib/moudle/admin/update_company.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/companys/add_company_controller.dart';
 import 'package:car_x/control/view_company/view_companys.dart';
 import 'package:flutter/material.dart';
@@ -14,15 +16,15 @@ addcopanycontrol controller1 = Get.put(
 );
 var ids = controller.id;
 Future<void> updatecompconn() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Company/update/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Company/update/$ids');
   var response = await http.post(url, body: {
     'nameCompany': controller1.compyname,
     'code': controller1.code,
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/admin/update_workshop.dart
+++ b/lib/moudle/admin/update_workshop.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/control/view_workshop/view_workshope_cont.dart';
 import 'package:car_x/control/worksope/workshope_controller.dart';
 import 'package:flutter/material.dart';
@@ -13,7 +15,7 @@ workashopcontrol controller = Get.put(
 );
 var ids = controller1.id;
 Future<void> updateworkshop() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Workshop/update/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Workshop/update/$ids');
   var response = await http.post(url, body: {
     'nameWorkshop': controller.name_ar,
     'phone': controller.phonenumber,
@@ -25,8 +27,8 @@ Future<void> updateworkshop() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/employee/aaddemployee.dart
+++ b/lib/moudle/employee/aaddemployee.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/moudle/admin/update_company.dart';
 import 'package:car_x/view/addempl/addemplcontroller.dart';
 import 'package:car_x/view/addempl/viewemployee/viewemployeecontroler.dart';
@@ -11,7 +13,7 @@ Future<void> addemployeeco() async {
     addemplocontroler(),
   );
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Employee/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Employee/save');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -25,8 +27,8 @@ Future<void> addemployeeco() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -70,7 +72,7 @@ Future<void> updateemployeeco() async {
   );
   var ids = controller1.id;
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Employee/update/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Employee/update/$ids');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -84,8 +86,8 @@ Future<void> updateemployeeco() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/moudle/saleman/aaddsaleman.dart
+++ b/lib/moudle/saleman/aaddsaleman.dart
@@ -1,5 +1,7 @@
 import 'package:car_x/view/addsaleman/addsalemancontroller.dart';
 import 'package:car_x/view/addsaleman/viewsaleman/viewsalemancontroler.dart';
+import 'package:car_x/config/api_config.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:get/get.dart';
@@ -14,7 +16,7 @@ Future<void> addsalemanconn() async {
   );
   var id = controller3.id;
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Salesman/setSalesman/$id');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Salesman/setSalesman/$id');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -28,8 +30,8 @@ Future<void> addsalemanconn() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,

--- a/lib/moudle/store/storeconn.dart
+++ b/lib/moudle/store/storeconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addempl/addemplcontroller.dart';
 import 'package:car_x/view/addempl/viewemployee/viewemployeecontroler.dart';
 import 'package:car_x/view/addstore/addstorescontroller.dart';
@@ -12,7 +14,7 @@ Future<void> addstorecon() async {
     addstorecontroler(),
   );
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Store/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/save');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -24,8 +26,8 @@ Future<void> addstorecon() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -69,7 +71,7 @@ Future<void> updatestoreco() async {
   );
   var ids = controller1.id;
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Store/update/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/update/$ids');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -81,8 +83,8 @@ Future<void> updatestoreco() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.back();
     Get.rawSnackbar(

--- a/lib/moudle/user_moudle/loginconnection.dart
+++ b/lib/moudle/user_moudle/loginconnection.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/control/user_controller/logincontroller.dart';
 
@@ -17,7 +19,7 @@ Future<void> loginco() async {
   Userlogincontroler controller =
       Get.put(Userlogincontroler(), permanent: true);
 
-  var url = Uri.parse('http://10.0.2.2:8000/api/login');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/login');
 
   var response = await http.post(url, body: {
     'mobile': controller.phonenumber,
@@ -25,8 +27,8 @@ Future<void> loginco() async {
   });
   var status = response.statusCode;
   data = jsonDecode(response.body);
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
 
   if (status == 200) {
     savetoken(data["access_token"]);

--- a/lib/moudle/user_moudle/logoutconn.dart
+++ b/lib/moudle/user_moudle/logoutconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -21,7 +23,7 @@ class logoutcontroller extends GetxController {
   var token;
 
   logoutco() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/logout');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/logout');
     var response =
         await http.post(url, headers: {'Authorization': 'Bearer $token'});
     var status = response.statusCode;
@@ -29,7 +31,7 @@ class logoutcontroller extends GetxController {
     if (status == 200) {
       Get.offAllNamed("signup");
 
-      print(data);
+      if (kDebugMode) debugPrint(data);
     }
   }
 }

--- a/lib/moudle/user_moudle/onbordcont.dart
+++ b/lib/moudle/user_moudle/onbordcont.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:car_x/control/user_controller/logincontroller.dart';
 
 import 'package:get/get.dart';
@@ -10,8 +11,8 @@ class onbordco extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
     per = prefs.getString("per");
-    print(token);
-    print(per);
+    if (kDebugMode) debugPrint(token);
+    if (kDebugMode) debugPrint(per);
     super.onInit();
   }
 

--- a/lib/moudle/user_moudle/singupconnection.dart
+++ b/lib/moudle/user_moudle/singupconnection.dart
@@ -1,14 +1,16 @@
 import 'package:car_x/control/user_controller/singupcontroller.dart';
+import 'package:car_x/config/api_config.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
 import 'package:lottie/lottie.dart';
 
 Future<void> singupco() async {
   Usersignupcontroler controller = Get.put(
     Usersignupcontroler(),
   );
-  var url = Uri.parse('http://10.0.2.2:8000/api/register');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/register');
   var response = await http.post(url, body: {
     'name': controller.username,
     'mobile': controller.phonenumber,
@@ -19,8 +21,10 @@ Future<void> singupco() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) {
+    debugPrint('Response status: ${response.statusCode}');
+    debugPrint('Response body: ${response.body}');
+  }
   if (response.body.contains("Authenticate")) {
     Get.rawSnackbar(
       messageText: LottieBuilder.asset(

--- a/lib/view/addcarpart/addcarpartconn.dart
+++ b/lib/view/addcarpart/addcarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:io';
 import 'package:car_x/view/addcarpart/addcarpartcontroller.dart';
 import 'package:flutter/material.dart';
@@ -12,7 +14,7 @@ addcarpartcontrol controller = Get.put(
 );
 var token = controller.token;
 uplodeimagepartconn() async {
-  var uri = Uri.parse('http://10.0.2.2:8000/api/Parts/save');
+  var uri = Uri.parse('${ApiConfig.baseUrl}/api/Parts/save');
   http.MultipartRequest request = http.MultipartRequest('POST', uri);
   var headers = {
     'Authorization': 'Bearer $token',
@@ -37,7 +39,7 @@ uplodeimagepartconn() async {
   var response = await request.send();
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -59,7 +61,7 @@ uplodeimagepartconn() async {
       backgroundColor: Colors.transparent,
     );
   } else if (status == 500) {
-    print(response.reasonPhrase);
+    if (kDebugMode) debugPrint(response.reasonPhrase);
     Get.rawSnackbar(
       titleText: Text(
         "اضف صور للقطعة",

--- a/lib/view/addcarpart/addcarpartcontroller.dart
+++ b/lib/view/addcarpart/addcarpartcontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -9,7 +10,7 @@ class addcarpartcontrol extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("carpartemptoken");
-    print(token);
+    if (kDebugMode) debugPrint(token);
 
     super.onInit();
   }

--- a/lib/view/addcarpart/carpartview/deletecarpart.dart
+++ b/lib/view/addcarpart/carpartview/deletecarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -15,12 +17,12 @@ class deletecarpartimagecontroller extends GetxController {
   var token;
   var id;
   deletecarpartimageconn() async {
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Parts/delete/${id}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Parts/delete/${id}');
     var response = await http.delete(
       uri,
       headers: {"Accept": "application/json", "Authorization": "Bearer $token"},
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.back();
       Get.rawSnackbar(

--- a/lib/view/addcarpart/carpartview/salequancontroller.dart
+++ b/lib/view/addcarpart/carpartview/salequancontroller.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addcarpart/addcarpartcontroller.dart';
 import 'package:car_x/view/addcarpart/carpartview/viwecarpartconn.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +19,7 @@ class saleqcarpartcontrol extends GetxController {
   Future<void> salequant() async {
     var token = controller.token;
     var id = controller1.id;
-    var url = Uri.parse('http://10.0.2.2:8000/api/Parts/Sale/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Parts/Sale/$id');
     var response = await http.post(url, headers: {
       "Accept": "application/json",
       "Authorization": "Bearer $token"
@@ -26,8 +28,8 @@ class saleqcarpartcontrol extends GetxController {
     });
 
     var status = response.statusCode;
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
     if (status == 200) {
       update();
       Get.back();

--- a/lib/view/addcarpart/carpartview/updatecarpartconn.dart
+++ b/lib/view/addcarpart/carpartview/updatecarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:io';
 import 'package:car_x/view/addcarpart/addcarpartcontroller.dart';
 import 'package:car_x/view/addcarpart/carpartview/viwecarpartconn.dart';
@@ -16,7 +18,7 @@ getallcarpartcontroller controller1 = Get.put(
 var id = controller1.id;
 var token = controller.token;
 uplodeupdateimagepartconn() async {
-  var uri = Uri.parse('http://10.0.2.2:8000/api/Parts/update/$id');
+  var uri = Uri.parse('${ApiConfig.baseUrl}/api/Parts/update/$id');
   http.MultipartRequest request = http.MultipartRequest('POST', uri);
   var headers = {
     'Authorization': 'Bearer $token',
@@ -41,7 +43,7 @@ uplodeupdateimagepartconn() async {
   var response = await request.send();
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -63,7 +65,7 @@ uplodeupdateimagepartconn() async {
       backgroundColor: Colors.transparent,
     );
   } else if (status == 500) {
-    print(response.reasonPhrase);
+    if (kDebugMode) debugPrint(response.reasonPhrase);
     Get.rawSnackbar(
       titleText: Text(
         "اضف صور للقطعة",

--- a/lib/view/addcarpart/carpartview/viewidetalicarpart.dart
+++ b/lib/view/addcarpart/carpartview/viewidetalicarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addcarpart/addcarpartcontroller.dart';
 import 'package:car_x/view/addcarpart/carpartview/deletecarpart.dart';
 import 'package:car_x/view/addcarpart/carpartview/salequancontroller.dart';
@@ -38,7 +40,7 @@ class viewimagecarpart extends StatelessWidget {
                             children: [
                               Container(
                                   child: Image.network(
-                                      "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                                      "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                           (controller2.data[index]['imagPart']
                                               .toString()))),
                               Row(

--- a/lib/view/addcarpart/carpartview/viwecarpartconn.dart
+++ b/lib/view/addcarpart/carpartview/viwecarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -16,12 +18,12 @@ class getallcarpartcontroller extends GetxController {
   List data = [];
 
   getallcarspaart() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Parts/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Parts/getAll');
     var response =
         await http.get(url, headers: {'Authorization': 'Bearer $token'});
     var status = response.statusCode;
     data = json.decode(response.body);
-    print(data);
+    if (kDebugMode) debugPrint(data);
     update();
   }
 }

--- a/lib/view/addcarpartuser/addcarpartconn.dart
+++ b/lib/view/addcarpartuser/addcarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:io';
 import 'package:car_x/view/addcarpartuser/addcarpartcontroller.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +12,7 @@ addcarpartusercontrol controller = Get.put(
 );
 var token = controller.token;
 uplodeimagepartuserconn() async {
-  var uri = Uri.parse('http://10.0.2.2:8000/api/User/Parts/save');
+  var uri = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/save');
   http.MultipartRequest request = http.MultipartRequest('POST', uri);
   var headers = {
     'Authorization': 'Bearer $token',
@@ -35,7 +37,7 @@ uplodeimagepartuserconn() async {
   var response = await request.send();
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -57,7 +59,7 @@ uplodeimagepartuserconn() async {
       backgroundColor: Colors.transparent,
     );
   } else if (status == 500) {
-    print(response.reasonPhrase);
+    if (kDebugMode) debugPrint(response.reasonPhrase);
     Get.rawSnackbar(
       titleText: Text(
         "اضف صور للقطعة",

--- a/lib/view/addcarpartuser/addcarpartcontroller.dart
+++ b/lib/view/addcarpartuser/addcarpartcontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -9,7 +10,7 @@ class addcarpartusercontrol extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
-    print(token);
+    if (kDebugMode) debugPrint(token);
 
     super.onInit();
   }

--- a/lib/view/addcarpartuser/carpartview/deletecarpart.dart
+++ b/lib/view/addcarpartuser/carpartview/deletecarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -15,12 +17,12 @@ class deletecarpartuserimagecontroller extends GetxController {
   var token;
   var id;
   deletecarpartuserimageconn() async {
-    var uri = Uri.parse('http://10.0.2.2:8000/api/User/Parts/delete/${id}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/delete/${id}');
     var response = await http.delete(
       uri,
       headers: {"Accept": "application/json", "Authorization": "Bearer $token"},
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.back();
       Get.rawSnackbar(

--- a/lib/view/addcarpartuser/carpartview/seaxhcarpart.dart
+++ b/lib/view/addcarpartuser/carpartview/seaxhcarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/addcarpartuser/carpartview/search.dart';
 import 'package:car_x/view/addcarpartuser/carpartview/ser.dart';
@@ -90,7 +92,7 @@ class viewcarpaart extends StatelessWidget {
                                     children: [
                                       Container(
                                           child: Image.network(
-                                              "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                                              "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                                   (controller22.data[index]
                                                           ['imagPart']
                                                       .toString()))),
@@ -270,18 +272,18 @@ class carpart extends GetxController {
 
   getallcarspaaartuser() async {
     Future.delayed(Duration(seconds: 2));
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Parts/viewAllPartsCar');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/viewAllPartsCar');
     var response =
         await http.get(url, headers: {'Authorization': 'Bearer $token'});
     var status = response.statusCode;
     data = json.decode(response.body);
-    print(data);
+    if (kDebugMode) debugPrint(data);
     update();
   }
 
   List car = [];
   searchpart() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Parts/filtering');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/filtering');
     var response = await http.post(url, headers: {
       'Authorization': 'Bearer $token'
     }, body: {
@@ -293,11 +295,11 @@ class carpart extends GetxController {
     var status = response.statusCode;
     data2 = json.decode(response.body);
     if (response.body.toString().contains('not')) {
-      print('--------');
+      if (kDebugMode) debugPrint('--------');
     } else {
       car = json.decode(response.body)[0]['imagPart'];
     }
-    print(data2);
+    if (kDebugMode) debugPrint(data2);
     update();
   }
 }

--- a/lib/view/addcarpartuser/carpartview/ser.dart
+++ b/lib/view/addcarpartuser/carpartview/ser.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addcarpartuser/carpartview/seaxhcarpart.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -22,7 +24,7 @@ class ser extends StatelessWidget {
                     children: [
                       Container(
                           child: Image.network(
-                              "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                              "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                   (controller2.data2[index]['imagPart']
                                       .toString()))),
                       Row(

--- a/lib/view/addcarpartuser/carpartview/updatecarpartconn.dart
+++ b/lib/view/addcarpartuser/carpartview/updatecarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:io';
 import 'package:car_x/view/addcarpartuser/addcarpartcontroller.dart';
 import 'package:car_x/view/addcarpartuser/carpartview/viwecarpartconn.dart';
@@ -16,7 +18,7 @@ getallcarpartusercontroller controller1 = Get.put(
 var id = controller1.id;
 var token = controller.token;
 uplodeupdateimagepartuserconn() async {
-  var uri = Uri.parse('http://10.0.2.2:8000/api/User/Parts/update/$id');
+  var uri = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/update/$id');
   http.MultipartRequest request = http.MultipartRequest('POST', uri);
   var headers = {
     'Authorization': 'Bearer $token',
@@ -41,7 +43,7 @@ uplodeupdateimagepartuserconn() async {
   var response = await request.send();
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 3,
@@ -63,7 +65,7 @@ uplodeupdateimagepartuserconn() async {
       backgroundColor: Colors.transparent,
     );
   } else if (status == 500) {
-    print(response.reasonPhrase);
+    if (kDebugMode) debugPrint(response.reasonPhrase);
     Get.rawSnackbar(
       titleText: Text(
         "اضف صور للقطعة",

--- a/lib/view/addcarpartuser/carpartview/viewidetalicarpart.dart
+++ b/lib/view/addcarpartuser/carpartview/viewidetalicarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addcarpart/addcarpartcontroller.dart';
 import 'package:car_x/view/addcarpart/carpartview/deletecarpart.dart';
 import 'package:car_x/view/addcarpart/carpartview/salequancontroller.dart';
@@ -39,7 +41,7 @@ class viewimagecarpartuser extends StatelessWidget {
                             children: [
                               Container(
                                   child: Image.network(
-                                      "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                                      "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                           (controller2.data[index]['imagPart']
                                               .toString()))),
                               Row(

--- a/lib/view/addcarpartuser/carpartview/viwecarpartconn.dart
+++ b/lib/view/addcarpartuser/carpartview/viwecarpartconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -26,12 +28,12 @@ class getallcarpartusercontroller extends GetxController {
 
   getallcarspaartuser() async {
     Future.delayed(Duration(seconds: 2));
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Parts/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Parts/getAll');
     var response =
         await http.get(url, headers: {'Authorization': 'Bearer $token'});
     var status = response.statusCode;
     data = json.decode(response.body);
-    print(data);
+    if (kDebugMode) debugPrint(data);
     update();
   }
 }

--- a/lib/view/addcarpartuser/order/viewmisscarpart.dart
+++ b/lib/view/addcarpartuser/order/viewmisscarpart.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/addcarpart/carpartview/viwecarpartconn.dart';
 import 'package:car_x/view/addcarpartuser/order/viewmyorder.dart';
@@ -39,7 +41,7 @@ class viewallmisscarpart extends StatelessWidget {
                               child: Column(children: [
                                 Container(
                                     child: Image.network(
-                                        "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                                        "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                             (controller.data[index]['imagPart']
                                                 .toString()))),
                                 Column(
@@ -138,7 +140,7 @@ class getallmisscarpart extends GetxController {
   var id;
   Future getallmisscarpartconn() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/Customer/Order/allMissingCarParts');
+        Uri.parse('${ApiConfig.baseUrl}/api/Customer/Order/allMissingCarParts');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -147,7 +149,7 @@ class getallmisscarpart extends GetxController {
     data = json.decode(response.body);
     if (status == 200) {
       item = data;
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }
@@ -155,7 +157,7 @@ class getallmisscarpart extends GetxController {
   var data2;
   Future sendorder() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Customer/Order/sendOrder/$carpartid/$storeid');
+        '${ApiConfig.baseUrl}/api/Customer/Order/sendOrder/$carpartid/$storeid');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -164,7 +166,7 @@ class getallmisscarpart extends GetxController {
     var status = response.statusCode;
     data2 = json.decode(response.body);
     if (status == 200) {
-      print(data2);
+      if (kDebugMode) debugPrint(data2);
       Get.rawSnackbar(
         barBlur: 3,
         titleText: Text(

--- a/lib/view/addcarpartuser/order/viewmyorder.dart
+++ b/lib/view/addcarpartuser/order/viewmyorder.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
@@ -40,7 +42,7 @@ class viewmyorder extends StatelessWidget {
                                             ? Image.network(
                                                 'https://www.gamian.eu/?attachment_id=72')
                                             : Image.network(
-                                                "http://10.0.2.2:8000/images/CarPartsPictures/" +
+                                                "${ApiConfig.baseUrl}/images/CarPartsPictures/" +
                                                     (controller.data[index]
                                                             ['car_parts']
                                                             ['imagPart']
@@ -140,7 +142,7 @@ class vieworder extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
     viewmyorderconn();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -151,7 +153,7 @@ class vieworder extends GetxController {
   var id;
   List part = [];
   Future viewmyorderconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Customer/Order/myOrder');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Customer/Order/myOrder');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -161,7 +163,7 @@ class vieworder extends GetxController {
     data = json.decode(response.body);
     if (status == 200) {
       part = data;
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }
@@ -169,7 +171,7 @@ class vieworder extends GetxController {
   var data2;
   Future deleteorder() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/Customer/Order/deleteOrder/$id');
+        Uri.parse('${ApiConfig.baseUrl}/api/Customer/Order/deleteOrder/$id');
     var response = await http.delete(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -197,7 +199,7 @@ class vieworder extends GetxController {
         duration: Duration(seconds: 2),
         backgroundColor: Colors.transparent,
       );
-      print(data2);
+      if (kDebugMode) debugPrint(data2);
       update();
     }
   }

--- a/lib/view/addempl/addemplcontroller.dart
+++ b/lib/view/addempl/addemplcontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,7 +8,7 @@ class addemplocontroler extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("emplotoken");
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 

--- a/lib/view/addempl/viewemployee/delete_employee.dart
+++ b/lib/view/addempl/viewemployee/delete_employee.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addempl/viewemployee/viewemployeecontroler.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -10,15 +12,15 @@ Future<void> deletemployconn() async {
   );
   var token = controller.token;
   var ids = controller.id;
-  var url = Uri.parse('http://10.0.2.2:8000/api/Employee/delete/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Employee/delete/$ids');
   var response = await http.delete(
     url,
     headers: {"Accept": "application/json", "Authorization": "Bearer $token"},
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/view/addempl/viewemployee/viewemployeecontroler.dart
+++ b/lib/view/addempl/viewemployee/viewemployeecontroler.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/addempl/viewemployee/viewemployee.dart';
 import 'package:get/get.dart';
@@ -24,7 +26,7 @@ class viewemployeecontroller extends GetxController {
   List data = [];
 
   Future<void> getallemployee() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Employee/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Employee/getAll');
 
     var response = await http.get(
       url,
@@ -34,8 +36,8 @@ class viewemployeecontroller extends GetxController {
 
     data = jsonDecode(response.body);
 
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
 
     if (status == 200) {
       Get.to(() => viewemployee());

--- a/lib/view/addsaleman/addsalemancontroller.dart
+++ b/lib/view/addsaleman/addsalemancontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,7 +8,7 @@ class addsalemancontroler extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("emplotoken");
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 

--- a/lib/view/addsaleman/viewsaleman/delete_saleman.dart
+++ b/lib/view/addsaleman/viewsaleman/delete_saleman.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addsaleman/viewsaleman/viewsalemancontroler.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -10,15 +12,15 @@ Future<void> deletesaleconn() async {
   );
   var token = controller.token;
   var ids = controller.id;
-  var url = Uri.parse('http://10.0.2.2:8000/api/Salesman/deleteSalesMan/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Salesman/deleteSalesMan/$ids');
   var response = await http.delete(
     url,
     headers: {"Accept": "application/json", "Authorization": "Bearer $token"},
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/view/addsaleman/viewsaleman/viewsalemancontroler.dart
+++ b/lib/view/addsaleman/viewsaleman/viewsalemancontroler.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/view/addsaleman/viewsaleman/viewesaleman.dart';
@@ -26,7 +28,7 @@ class viewesaleecontroller extends GetxController {
 
   var id;
   Future<void> getallsaleman() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Salesman/getSalesman/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Salesman/getSalesman/$id');
 
     var response = await http.get(
       url,
@@ -36,8 +38,8 @@ class viewesaleecontroller extends GetxController {
 
     data = jsonDecode(response.body);
 
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
 
     if (status == 200) {
       Get.to(() => viewsaleman());

--- a/lib/view/addstore/addstorescontroller.dart
+++ b/lib/view/addstore/addstorescontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,7 +8,7 @@ class addstorecontroler extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("emplotoken");
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 

--- a/lib/view/addstore/viewemployee/delete_store.dart
+++ b/lib/view/addstore/viewemployee/delete_store.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addempl/viewemployee/viewemployeecontroler.dart';
 import 'package:car_x/view/addstore/viewemployee/viewstorescontroler.dart';
 import 'package:flutter/material.dart';
@@ -11,15 +13,15 @@ Future<void> deletstoreconn() async {
   );
   var token = controller.token;
   var ids = controller.id;
-  var url = Uri.parse('http://10.0.2.2:8000/api/Store/deleteStore/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/deleteStore/$ids');
   var response = await http.delete(
     url,
     headers: {"Accept": "application/json", "Authorization": "Bearer $token"},
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/view/addstore/viewemployee/frezz_store.dart
+++ b/lib/view/addstore/viewemployee/frezz_store.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addstore/viewemployee/viewstorescontroler.dart';
 import 'package:flutter/material.dart';
 
@@ -10,14 +12,14 @@ viewestorecontroller controller = Get.put(
 );
 var ids = controller.id;
 Future<void> frezzstoreconn() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Store/freeze/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/freeze/$ids');
   var response = await http.post(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/view/addstore/viewemployee/unfrezz_store.dart
+++ b/lib/view/addstore/viewemployee/unfrezz_store.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/addstore/viewemployee/viewstorescontroler.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -9,14 +11,14 @@ viewestorecontroller controller = Get.put(
 );
 var ids = controller.id;
 Future<void> unfrezzstoreconn() async {
-  var url = Uri.parse('http://10.0.2.2:8000/api/Store/unfreeze/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/unfreeze/$ids');
   var response = await http.post(
     url,
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   if (status == 200) {
     Get.rawSnackbar(
       barBlur: 2,

--- a/lib/view/addstore/viewemployee/viewstorescontroler.dart
+++ b/lib/view/addstore/viewemployee/viewstorescontroler.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/addempl/viewemployee/viewemployee.dart';
 import 'package:car_x/view/addstore/viewemployee/viewestore.dart';
@@ -24,7 +26,7 @@ class viewestorecontroller extends GetxController {
   List data = [];
 
   Future<void> getallstores() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Store/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Store/getAll');
 
     var response = await http.get(
       url,
@@ -34,8 +36,8 @@ class viewestorecontroller extends GetxController {
 
     newMethod(response);
 
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
 
     if (status == 200) {
       Get.to(() => viewestores());

--- a/lib/view/cars/addcar/addcarconn.dart
+++ b/lib/view/cars/addcar/addcarconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/view/cars/addcar/addcarcontroller.dart';
@@ -16,7 +18,7 @@ Future<void> addcarconn() async {
   );
 
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/Car/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/save');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -35,8 +37,8 @@ Future<void> addcarconn() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   var data = json.decode(response.body);
   controller1.ids = data["id"];
   if (status == 200) {

--- a/lib/view/cars/addcar/addcarcontroller.dart
+++ b/lib/view/cars/addcar/addcarcontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -9,7 +10,7 @@ class addcarcontrol extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("caremptoken");
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -47,7 +48,7 @@ class addcarcontrol extends GetxController {
       image!.addAll(_image!);
     }
     for (var i = 0; i < image!.length; i++) {
-      print(image![i].path.toString().split('/').last);
+      if (kDebugMode) debugPrint(image![i].path.toString().split('/').last);
     }
   }
 }

--- a/lib/view/cars/image/deletecarimag.dart
+++ b/lib/view/cars/image/deletecarimag.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -23,14 +25,14 @@ class deleteimagecontroller extends GetxController {
   deleteimageconn() async {
     var ids = controller1.id;
     var imagename = controller1.imagename;
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/deleteimage/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/deleteimage/${ids}');
     var response = await http.post(uri, headers: {
       "Accept": "application/json",
       "Authorization": "Bearer $token"
     }, body: {
       'imageName': imagename,
     });
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,

--- a/lib/view/cars/image/getallcars.dart
+++ b/lib/view/cars/image/getallcars.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -25,7 +27,7 @@ class getallcarcontroller extends GetxController {
   var detaildata;
   Future getallcars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/getAll');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",

--- a/lib/view/cars/image/uplodecarimage.dart
+++ b/lib/view/cars/image/uplodecarimage.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:io';
 import 'package:car_x/view/cars/addcar/addcarcontroller.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
@@ -28,7 +30,7 @@ class uplodimagecontroller extends GetxController {
   var token;
   var ids;
   uplodeimageconn() async {
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/uploadImage/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/uploadImage/${ids}');
     http.MultipartRequest request = http.MultipartRequest('POST', uri);
     request.headers['Authorization'] = 'Bearer $token';
     if (controller.image!.isNotEmpty) {
@@ -43,15 +45,15 @@ class uplodimagecontroller extends GetxController {
       var response = await request.send();
 
       if (response.statusCode == 200) {
-        print(await response.stream.bytesToString());
+        if (kDebugMode) debugPrint(await response.stream.bytesToString());
       } else {
-        print(response.reasonPhrase);
+        if (kDebugMode) debugPrint(response.reasonPhrase);
       }
     } else {}
   }
 
   uplodemyimageconn() async {
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/uploadImage/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/uploadImage/${ids}');
     http.MultipartRequest request = http.MultipartRequest('POST', uri);
     request.headers['Authorization'] = 'Bearer $token';
     if (controller2.image!.isNotEmpty) {
@@ -66,9 +68,9 @@ class uplodimagecontroller extends GetxController {
       var response = await request.send();
 
       if (response.statusCode == 200) {
-        print(await response.stream.bytesToString());
+        if (kDebugMode) debugPrint(await response.stream.bytesToString());
       } else {
-        print(response.reasonPhrase);
+        if (kDebugMode) debugPrint(response.reasonPhrase);
       }
     } else {}
   }

--- a/lib/view/cars/image/viewimages.dart
+++ b/lib/view/cars/image/viewimages.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/deletecarimag.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:flutter/material.dart';
@@ -30,7 +32,7 @@ class viewimages extends StatelessWidget {
                                   children: [
                                     Container(
                                       child: Image.network(
-                                        "http://10.0.2.2:8000/images/CarPictures/" +
+                                        "${ApiConfig.baseUrl}/images/CarPictures/" +
                                             (controller2.imagecar[index]
                                                     ['imageName']
                                                 .toString()),

--- a/lib/view/googlemap.dart
+++ b/lib/view/googlemap.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'package:car_x/control/worksope/workshope_controller.dart'; // Assuming this path is correct
 import 'package:flutter/material.dart';
@@ -91,7 +92,7 @@ class MapSampleState extends State<MapSample> {
           _errorMessage = e.toString();
         });
       }
-      print("Error initializing map: $e");
+      if (kDebugMode) debugPrint("Error initializing map: $e");
     }
   }
 
@@ -112,14 +113,14 @@ class MapSampleState extends State<MapSample> {
                 long = draggedLatLng.longitude;
               });
             }
-            print("Marker dragged to: $draggedLatLng");
+            if (kDebugMode) debugPrint("Marker dragged to: $draggedLatLng");
           },
           icon: BitmapDescriptor.defaultMarkerWithHue(
               BitmapDescriptor.hueAzure), // Custom marker color
         )
       ];
     });
-    print("Tapped at: $point");
+    if (kDebugMode) debugPrint("Tapped at: $point");
   }
 
   void _goToCurrentUserLocation() {

--- a/lib/view/home/bookings/book.dart
+++ b/lib/view/home/bookings/book.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/moudle/user_moudle/loginconnection.dart';
@@ -29,7 +31,7 @@ class booking extends GetxController {
   var token;
   var datac;
   Future sendbooking() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Booking/bookingCar/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/bookingCar/$id');
     var response = await http.post(
       url,
       headers: {
@@ -40,8 +42,8 @@ class booking extends GetxController {
 
     var status = response.statusCode;
     datac = jsonDecode(response.body);
-    print(response.body);
-    print(status);
+    if (kDebugMode) debugPrint(response.body);
+    if (kDebugMode) debugPrint(status);
 
     if (data.toString().contains('false')) {
       Get.rawSnackbar(
@@ -112,7 +114,7 @@ class booking extends GetxController {
 
   Future cancelebooking() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/User/Booking/cancellationOfBooking/$id');
+        '${ApiConfig.baseUrl}/api/User/Booking/cancellationOfBooking/$id');
     var response = await http.post(
       url,
       headers: {
@@ -123,7 +125,7 @@ class booking extends GetxController {
 
     var status = response.statusCode;
     var datax = response.body;
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (data.toString().contains('false')) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -145,7 +147,7 @@ class booking extends GetxController {
         backgroundColor: Colors.transparent,
       );
     } else {
-      print(datax);
+      if (kDebugMode) debugPrint(datax);
       Get.rawSnackbar(
         barBlur: 3,
         titleText: Text(
@@ -177,7 +179,7 @@ class booking extends GetxController {
   var data1;
   var data2;
   Future mybooking() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Booking/myBookings');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/myBookings');
     var response = await http.get(
       url,
       headers: {
@@ -190,11 +192,11 @@ class booking extends GetxController {
     data = json.decode(response.body);
     item = data;
 
-    print(data);
+    if (kDebugMode) debugPrint(data);
   }
 
   Future rentbooking() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Booking/soldBookings');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/soldBookings');
     var response = await http.get(
       url,
       headers: {
@@ -207,11 +209,11 @@ class booking extends GetxController {
     data1 = json.decode(response.body);
     item1 = data1;
     update();
-    print(data1);
+    if (kDebugMode) debugPrint(data1);
   }
 
   Future soldbooking() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Booking/soldBookings');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/soldBookings');
     var response = await http.get(
       url,
       headers: {
@@ -224,12 +226,12 @@ class booking extends GetxController {
     data2 = json.decode(response.body);
     item2 = data2;
     update();
-    print(data2);
+    if (kDebugMode) debugPrint(data2);
   }
 
   Future conformreq() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/User/Booking/confirmRequest/$id');
+        Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/confirmRequest/$id');
     var response = await http.get(
       url,
       headers: {
@@ -241,7 +243,7 @@ class booking extends GetxController {
     var status = response.statusCode;
 
     update();
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (status == 200) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -267,7 +269,7 @@ class booking extends GetxController {
 
   Future rejectreq() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/User/Booking/rejectionBooking/$id');
+        Uri.parse('${ApiConfig.baseUrl}/api/User/Booking/rejectionBooking/$id');
     var response = await http.get(
       url,
       headers: {
@@ -279,7 +281,7 @@ class booking extends GetxController {
     var status = response.statusCode;
 
     update();
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (status == 200) {
       Get.rawSnackbar(
         barBlur: 3,

--- a/lib/view/home/caruser/addcar/addcarconn.dart
+++ b/lib/view/home/caruser/addcar/addcarconn.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/cars/image/uplodecarimage.dart';
 import 'package:car_x/view/home/caruser/addcar/addcarcontroller.dart';
@@ -14,7 +16,7 @@ Future<void> addmycarconn() async {
     uplodimagecontroller(),
   );
   var token = controller.token.toString();
-  var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/save');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/save');
   var response = await http.post(url, headers: {
     "Accept": "application/json",
     "Authorization": "Bearer $token"
@@ -33,8 +35,8 @@ Future<void> addmycarconn() async {
   });
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
   var data = json.decode(response.body);
   controller1.ids = data["id"];
   if (status == 200) {

--- a/lib/view/home/caruser/addcar/addcarcontroller.dart
+++ b/lib/view/home/caruser/addcar/addcarcontroller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -10,7 +11,7 @@ class addmycarcontrol extends GetxController {
   Future<void> onInit() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
-    print(token);
+    if (kDebugMode) debugPrint(token);
 
     super.onInit();
   }

--- a/lib/view/home/caruser/rentcar.dart
+++ b/lib/view/home/caruser/rentcar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -9,7 +11,7 @@ class rentmycar extends GetxController {
   var bookingPeriod;
   var id;
   Future<void> myrentcarconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/carRental/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/carRental/$id');
     var response = await http.post(url, body: {
       'tenantName': tenantName,
       'tenantPhoneNumber': tenantPhoneNumber,
@@ -17,7 +19,7 @@ class rentmycar extends GetxController {
     });
 
     var status = response.statusCode;
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (status == 200) {
       Get.rawSnackbar(
         barBlur: 2,

--- a/lib/view/home/caruser/sellcar.dart
+++ b/lib/view/home/caruser/sellcar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -8,7 +10,7 @@ class sellmycar extends GetxController {
   var buyersPhoneNumber;
   var id;
   Future<void> mysellcarconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/saleCar/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/saleCar/$id');
     var response = await http.post(url,
         body: {'buyerName': buyerName, 'buyersPhoneNumber': buyersPhoneNumber});
 

--- a/lib/view/home/detailesfoecaruserselected.dart
+++ b/lib/view/home/detailesfoecaruserselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/bookings/book.dart';
 import 'package:car_x/view/home/getallmycar.dart';
 import 'package:car_x/view/home/getallusercars.dart';
@@ -52,7 +54,7 @@ class _cardetailsforuserState extends State<cardetailsforuser> {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.cover,

--- a/lib/view/home/detailesfoemycarselected.dart
+++ b/lib/view/home/detailesfoemycarselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/caruser/rentcar.dart';
 import 'package:car_x/view/home/caruser/sellcar.dart';
 import 'package:car_x/view/home/getallmycar.dart';
@@ -36,7 +38,7 @@ class cardetailsformycar extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.fill,

--- a/lib/view/home/getallmycar.dart
+++ b/lib/view/home/getallmycar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -9,7 +11,7 @@ class getallmycarcontroller extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
     getallmycarsuser();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -22,7 +24,7 @@ class getallmycarcontroller extends GetxController {
   List imagecardetail = [];
   var detaildata;
   Future getallmycarsuser() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/getAllMyCars');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/getAllMyCars');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -33,7 +35,7 @@ class getallmycarcontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }

--- a/lib/view/home/getallusercars.dart
+++ b/lib/view/home/getallusercars.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -9,7 +11,7 @@ class getallcarusercontroller extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("token");
     getallcarsuser();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -30,7 +32,7 @@ class getallcarusercontroller extends GetxController {
   var detaildata;
   Future<void> getallcarsuser() async {
     Future.delayed(Duration(seconds: 2));
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/getAll');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/getAll');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -43,7 +45,7 @@ class getallcarusercontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }

--- a/lib/view/home/homepage.dart
+++ b/lib/view/home/homepage.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/bookings/mybooking.dart';
 import 'package:car_x/view/home/bookings/rentbooking.dart';
 import 'package:car_x/view/home/bookings/soldbook.dart';
@@ -279,7 +281,7 @@ class Homepage extends StatelessWidget {
                                     itemBuilder: (context, index, rindex) {
                                       return Container(
                                           child: Image.network(
-                                        "http://10.0.2.2:8000/images/CarPictures/" +
+                                        "${ApiConfig.baseUrl}/images/CarPictures/" +
                                             (controller.imagecar[index]
                                                     ['imageName']
                                                 .toString()),
@@ -386,7 +388,7 @@ mycars() {
                               itemBuilder: (context, index, rindex) {
                                 return Container(
                                     child: Image.network(
-                                  "http://10.0.2.2:8000/images/CarPictures/" +
+                                  "${ApiConfig.baseUrl}/images/CarPictures/" +
                                       (controller.imagecar[index]['imageName']
                                           .toString()),
                                   fit: BoxFit.fill,

--- a/lib/view/home/loved.dart
+++ b/lib/view/home/loved.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/getallusercars.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -10,13 +12,13 @@ Future loved() async {
   );
   var token = controller.token;
   var ids = controller.loveid;
-  var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/LoveCar/$ids');
+  var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/LoveCar/$ids');
   var response = await http.post(
     url,
     headers: {"Authorization": "Bearer $token"},
   );
 
   var status = response.statusCode;
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
+  if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+  if (kDebugMode) debugPrint('Response body: ${response.body}');
 }

--- a/lib/view/homeforemployee/bookings/bookemp.dart
+++ b/lib/view/homeforemployee/bookings/bookemp.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -22,7 +24,7 @@ class bookingemploo extends GetxController {
   var token;
   Future sendbookingemplo() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/Employee/Booking/bookingCar/$id');
+        Uri.parse('${ApiConfig.baseUrl}/api/Employee/Booking/bookingCar/$id');
     var response = await http.post(
       url,
       headers: {
@@ -33,7 +35,7 @@ class bookingemploo extends GetxController {
 
     var status = response.statusCode;
 
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (response.body.isNotEmpty) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -61,7 +63,7 @@ class bookingemploo extends GetxController {
 
   Future cancelebookingemplo() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Employee/Booking/cancellationOfBooking/$id');
+        '${ApiConfig.baseUrl}/api/Employee/Booking/cancellationOfBooking/$id');
     var response = await http.post(
       url,
       headers: {
@@ -72,7 +74,7 @@ class bookingemploo extends GetxController {
 
     var status = response.statusCode;
 
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (response.body.isNotEmpty) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -107,7 +109,7 @@ class bookingemploo extends GetxController {
 
   Future rentbookingemploo() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Employee/Booking/getRequestRentalBookings');
+        '${ApiConfig.baseUrl}/api/Employee/Booking/getRequestRentalBookings');
     var response = await http.get(
       url,
       headers: {
@@ -122,12 +124,12 @@ class bookingemploo extends GetxController {
       item1 = data1;
     }
     update();
-    print(data1);
+    if (kDebugMode) debugPrint(data1);
   }
 
   Future soldbookingemploo() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Employee/Booking/getRequestSoldBookings');
+        '${ApiConfig.baseUrl}/api/Employee/Booking/getRequestSoldBookings');
     var response = await http.get(
       url,
       headers: {
@@ -142,12 +144,12 @@ class bookingemploo extends GetxController {
       item2 = data2;
     }
     update();
-    print(data2);
+    if (kDebugMode) debugPrint(data2);
   }
 
   Future conformreqemploo() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Employee/Booking/confirmRequest/$id');
+        '${ApiConfig.baseUrl}/api/Employee/Booking/confirmRequest/$id');
     var response = await http.get(
       url,
       headers: {
@@ -159,7 +161,7 @@ class bookingemploo extends GetxController {
     var status = response.statusCode;
 
     update();
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (status == 200) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -185,7 +187,7 @@ class bookingemploo extends GetxController {
 
   Future rejectreqemploo() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Employee/Booking/rejectionBooking/$id');
+        '${ApiConfig.baseUrl}/api/Employee/Booking/rejectionBooking/$id');
     var response = await http.get(
       url,
       headers: {
@@ -197,7 +199,7 @@ class bookingemploo extends GetxController {
     var status = response.statusCode;
 
     update();
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (status == 200) {
       Get.rawSnackbar(
         barBlur: 3,

--- a/lib/view/homeforemployee/deletecar.dart
+++ b/lib/view/homeforemployee/deletecar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/home/getallmycar.dart';
 import 'package:car_x/view/home/getallusercars.dart';
@@ -32,11 +34,11 @@ class deletecar extends GetxController {
   deletecarconn() async {
     var ids = controller1.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,
@@ -63,11 +65,11 @@ class deletecar extends GetxController {
   deletemycarconn() async {
     var ids = controller.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,
@@ -94,11 +96,11 @@ class deletecar extends GetxController {
   deletecarsellconn() async {
     var ids = controller2.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,
@@ -125,11 +127,11 @@ class deletecar extends GetxController {
   deletecarsoldconn() async {
     var ids = controller3.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,
@@ -156,11 +158,11 @@ class deletecar extends GetxController {
   deletecarrentconn() async {
     var ids = controller4.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,
@@ -187,11 +189,11 @@ class deletecar extends GetxController {
   deletecarrentedconn() async {
     var ids = controller5.id;
 
-    var uri = Uri.parse('http://10.0.2.2:8000/api/Car/delete/${ids}');
+    var uri = Uri.parse('${ApiConfig.baseUrl}/api/Car/delete/${ids}');
     var response = await http.delete(
       uri,
     );
-    print(response.body);
+    if (kDebugMode) debugPrint(response.body);
     if (response.statusCode == 200) {
       Get.rawSnackbar(
         barBlur: 2,

--- a/lib/view/homeforemployee/detailesfoecarselected.dart
+++ b/lib/view/homeforemployee/detailesfoecarselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/homeforemployee/bookings/bookemp.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
@@ -54,7 +56,7 @@ class _cardetailsforemploState extends State<cardetailsforemplo> {
               itemBuilder: (context, index, rindex) {
                 return Container(
                     child: Image.network(
-                  "http://10.0.2.2:8000/images/CarPictures/" +
+                  "${ApiConfig.baseUrl}/images/CarPictures/" +
                       (controller.detaildata['image_car'][index]['imageName']
                           .toString()),
                   fit: BoxFit.cover,

--- a/lib/view/homeforemployee/homeforemployee.dart
+++ b/lib/view/homeforemployee/homeforemployee.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/homeforemployee/bookings/mybooking.dart';
 import 'package:car_x/view/homeforemployee/bookings/rentbooking.dart';
@@ -198,7 +200,7 @@ class Homepageforemployee extends StatelessWidget {
                                   itemBuilder: (context, index, rindex) {
                                     return Container(
                                         child: Image.network(
-                                      "http://10.0.2.2:8000/images/CarPictures/" +
+                                      "${ApiConfig.baseUrl}/images/CarPictures/" +
                                           (controller.imagecar[index]
                                                   ['imageName']
                                               .toString()),

--- a/lib/view/homeforemployee/rentcar.dart
+++ b/lib/view/homeforemployee/rentcar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -9,7 +11,7 @@ class rentcar extends GetxController {
   var bookingPeriod;
   var id;
   Future<void> rentcarconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/carRental/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/carRental/$id');
     var response = await http.post(url, body: {
       'tenantName': tenantName,
       'tenantPhoneNumber': tenantPhoneNumber,

--- a/lib/view/homeforemployee/sellcar.dart
+++ b/lib/view/homeforemployee/sellcar.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
@@ -8,7 +10,7 @@ class sellcar extends GetxController {
   var buyersPhoneNumber;
   var id;
   Future<void> sellcarconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/saleCar/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/saleCar/$id');
     var response = await http.post(url,
         body: {'buyerName': buyerName, 'buyersPhoneNumber': buyersPhoneNumber});
 
@@ -56,7 +58,7 @@ class sellcar extends GetxController {
           backgroundColor: Colors.transparent,
         );
       }
-      print(response.body);
+      if (kDebugMode) debugPrint(response.body);
 
       update();
     }

--- a/lib/view/homeforemployee/updatecarcontroller.dart
+++ b/lib/view/homeforemployee/updatecarcontroller.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/view/cars/addcar/addcarcontroller.dart';
@@ -36,7 +38,7 @@ class updatecarcontroller extends GetxController {
 
   Future<void> updatecarconn() async {
     var token = controller1.token.toString();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/update/$id');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/update/$id');
     var response = await http.post(url, headers: {
       "Accept": "application/json",
       "Authorization": "Bearer $token"
@@ -54,8 +56,8 @@ class updatecarcontroller extends GetxController {
     });
 
     var status = response.statusCode;
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    if (kDebugMode) debugPrint('Response status: ${response.statusCode}');
+    if (kDebugMode) debugPrint('Response body: ${response.body}');
     var data = json.decode(response.body);
 
     if (status == 200) {

--- a/lib/view/manegerdashpord/detailesfoecaruserselected.dart
+++ b/lib/view/manegerdashpord/detailesfoecaruserselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/bookings/book.dart';
 import 'package:car_x/view/home/getallmycar.dart';
 import 'package:car_x/view/home/getallusercars.dart';
@@ -52,7 +54,7 @@ class _cardetailsforallState extends State<cardetailsforall> {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.cover,

--- a/lib/view/manegerdashpord/homepage.dart
+++ b/lib/view/manegerdashpord/homepage.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/bookings/mybooking.dart';
 import 'package:car_x/view/home/bookings/rentbooking.dart';
 import 'package:car_x/view/home/bookings/soldbook.dart';
@@ -172,7 +174,7 @@ class Homepageman extends StatelessWidget {
                                     itemBuilder: (context, index, rindex) {
                                       return Container(
                                           child: Image.network(
-                                        "http://10.0.2.2:8000/images/CarPictures/" +
+                                        "${ApiConfig.baseUrl}/images/CarPictures/" +
                                             (controller.imagecar[index]
                                                     ['imageName']
                                                 .toString()),
@@ -279,7 +281,7 @@ mycars() {
                               itemBuilder: (context, index, rindex) {
                                 return Container(
                                     child: Image.network(
-                                  "http://10.0.2.2:8000/images/CarPictures/" +
+                                  "${ApiConfig.baseUrl}/images/CarPictures/" +
                                       (controller.imagecar[index]['imageName']
                                           .toString()),
                                   fit: BoxFit.fill,

--- a/lib/view/rent/detailesfoecarrentedselected.dart
+++ b/lib/view/rent/detailesfoecarrentedselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
@@ -36,7 +38,7 @@ class carrenteddetailsforemplo extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.fill,

--- a/lib/view/rent/detailesfoecarrentselected.dart
+++ b/lib/view/rent/detailesfoecarrentselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
 import 'package:car_x/view/homeforemployee/sellcar.dart';
@@ -34,7 +36,7 @@ class carrentdetailsforemplo extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.fill,

--- a/lib/view/rent/forsell.dart
+++ b/lib/view/rent/forsell.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/rent/detailesfoecarrentselected.dart';
 
 import 'package:carousel_slider/carousel_slider.dart';
@@ -83,7 +85,7 @@ class forrent extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -128,7 +130,7 @@ class getallrentcarcontroller extends GetxController {
   var detaildata;
   Future getallrentcars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/getAllForRental');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/getAllForRental');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -139,7 +141,7 @@ class getallrentcarcontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(car);
+      if (kDebugMode) debugPrint(car);
     }
   }
 }

--- a/lib/view/rent/sold.dart
+++ b/lib/view/rent/sold.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/detailesfoecaruserselected.dart';
 import 'package:car_x/view/rent/detailesfoecarrentedselected.dart';
 
@@ -84,7 +86,7 @@ class rented extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -130,7 +132,7 @@ class getallrentedcarcontroller extends GetxController {
   var detaildata;
   Future getallrentedcars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/getAllRentalCars');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/getAllRentalCars');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -145,7 +147,7 @@ class getallrentedcarcontroller extends GetxController {
       }
 
       update();
-      print(data);
+      if (kDebugMode) debugPrint(data);
     }
   }
 }

--- a/lib/view/requestment/requestment.dart
+++ b/lib/view/requestment/requestment.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/requestment/viewavworkshop.dart';
 import 'package:geolocator/geolocator.dart';
@@ -138,7 +140,7 @@ class getallmentreqcontroller extends GetxController {
     token = prefs.getString("token");
     await getallmentreqconn();
     update();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -151,7 +153,7 @@ class getallmentreqcontroller extends GetxController {
   List reqx = [];
   Future getallmentreqconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Customer/Maintenance/myMaintenanceRequest');
+        '${ApiConfig.baseUrl}/api/Customer/Maintenance/myMaintenanceRequest');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -161,7 +163,7 @@ class getallmentreqcontroller extends GetxController {
     data = json.decode(response.body);
     if (status == 200) {
       reqx = data;
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }
@@ -169,7 +171,7 @@ class getallmentreqcontroller extends GetxController {
   var data2;
   Future sendreqconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Customer/Maintenance/sendRequest/$woid');
+        '${ApiConfig.baseUrl}/api/Customer/Maintenance/sendRequest/$woid');
     var response = await http.post(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -181,7 +183,7 @@ class getallmentreqcontroller extends GetxController {
     refresh();
     var status = response.statusCode;
 
-    print(status);
+    if (kDebugMode) debugPrint(status);
     if (response.body.isNotEmpty) {
       Get.rawSnackbar(
         barBlur: 3,
@@ -210,7 +212,7 @@ class getallmentreqcontroller extends GetxController {
   var data3;
   Future deletereqconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/Customer/Maintenance/deleteRequest/$id');
+        '${ApiConfig.baseUrl}/api/Customer/Maintenance/deleteRequest/$id');
     var response = await http.delete(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -219,7 +221,7 @@ class getallmentreqcontroller extends GetxController {
     var status = response.statusCode;
     data3 = json.decode(response.body);
     if (status == 200) {
-      print(data3);
+      if (kDebugMode) debugPrint(data3);
       Get.rawSnackbar(
         barBlur: 3,
         titleText: Text(
@@ -273,7 +275,7 @@ class getallmentreqcontroller extends GetxController {
       currentPosition = position;
       update();
     }).catchError((e) {
-      print(e);
+      if (kDebugMode) debugPrint(e);
     });
   }
 }

--- a/lib/view/requestment/viewavworkshop.dart
+++ b/lib/view/requestment/viewavworkshop.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 import 'package:car_x/view/requestment/requestment.dart';
 import 'package:http/http.dart' as http;
@@ -232,7 +234,7 @@ class viewavworkshops extends GetxController {
     token = prefs.getString("token");
     await viewavworkshop();
     update();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -245,7 +247,7 @@ class viewavworkshops extends GetxController {
 
   Future viewavworkshop() async {
     var url =
-        Uri.parse('http://10.0.2.2:8000/api/Customer/Maintenance/getWorkShops');
+        Uri.parse('${ApiConfig.baseUrl}/api/Customer/Maintenance/getWorkShops');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -257,7 +259,7 @@ class viewavworkshops extends GetxController {
       if (response.body.toString().contains('no')) {
       } else {
         data = json.decode(response.body);
-        print(data);
+        if (kDebugMode) debugPrint(data);
       }
       update();
     }

--- a/lib/view/searchbar/resultesearch.dart
+++ b/lib/view/searchbar/resultesearch.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/searchbar/search.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
@@ -44,7 +46,7 @@ class resultsearch extends StatelessWidget {
                               itemBuilder: (context, index, rindex) {
                                 return Container(
                                     child: Image.network(
-                                  "http://10.0.2.2:8000/images/CarPictures/${controller.data[rindex]['image_car'][rindex]['imageName']}",
+                                  "${ApiConfig.baseUrl}/images/CarPictures/${controller.data[rindex]['image_car'][rindex]['imageName']}",
                                   fit: BoxFit.fill,
                                 ));
                               },

--- a/lib/view/searchbar/search.dart
+++ b/lib/view/searchbar/search.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'dart:convert';
 
 import 'package:car_x/moudle/admin/frezz.dart';
@@ -281,7 +283,7 @@ class searchbar extends GetxController {
   List imagecardetail = [];
   var detaildata;
   Future searchconn() async {
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/search');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/search');
     var response = await http.post(url, body: {
       'name': name,
       'manufacturingYear': manufacturingYear,
@@ -295,9 +297,9 @@ class searchbar extends GetxController {
     car = data;
     if (response.statusCode == 200) {
       update();
-      print(data);
+      if (kDebugMode) debugPrint(data);
     } else {
-      print(response.reasonPhrase);
+      if (kDebugMode) debugPrint(response.reasonPhrase);
     }
   }
 }

--- a/lib/view/sell copy/detailesfoecarsellselected.dart
+++ b/lib/view/sell copy/detailesfoecarsellselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
 import 'package:car_x/view/homeforemployee/sellcar.dart';
@@ -24,7 +26,7 @@ class carselldetailsforuser extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.cover,

--- a/lib/view/sell copy/detailesfoecarsoldselected.dart
+++ b/lib/view/sell copy/detailesfoecarsoldselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
 import 'package:car_x/view/homeforemployee/sellcar.dart';
@@ -24,7 +26,7 @@ class carrentdetailsforuser extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.cover,

--- a/lib/view/sell copy/forsell copy.dart
+++ b/lib/view/sell copy/forsell copy.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/rent/detailesfoecarrentselected.dart';
 import 'package:car_x/view/sell%20copy/detailesfoecarsoldselected.dart';
 
@@ -84,7 +86,7 @@ class forrents extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -136,7 +138,7 @@ class getallrentscarcontroller extends GetxController {
   var detaildata;
   Future getallrentscars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/getAllForRental');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/getAllForRental');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -147,7 +149,7 @@ class getallrentscarcontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(car);
+      if (kDebugMode) debugPrint(car);
     }
   }
 }

--- a/lib/view/sell copy/forsell.dart
+++ b/lib/view/sell copy/forsell.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/detailesfoecaruserselected.dart';
 import 'package:car_x/view/sell%20copy/detailesfoecarsellselected.dart';
 import 'package:car_x/view/sell/detailesfoecarsellselected.dart';
@@ -85,7 +87,7 @@ class forsells extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -136,7 +138,7 @@ class getallsellscarcontroller extends GetxController {
   var detaildata;
   Future getallsellscars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/User/Car/getAllForSelling');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/User/Car/getAllForSelling');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -147,7 +149,7 @@ class getallsellscarcontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(car);
+      if (kDebugMode) debugPrint(car);
     }
   }
 }

--- a/lib/view/sell/detailesfoecarsellselected.dart
+++ b/lib/view/sell/detailesfoecarsellselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
@@ -35,7 +37,7 @@ class carselldetailsforemplo extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.fill,

--- a/lib/view/sell/detailesfoecarsoldselected.dart
+++ b/lib/view/sell/detailesfoecarsoldselected.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/cars/image/getallcars.dart';
 import 'package:car_x/view/homeforemployee/deletecar.dart';
 import 'package:car_x/view/homeforemployee/rentcar.dart';
@@ -35,7 +37,7 @@ class carsolddetailsforemplo extends StatelessWidget {
             itemBuilder: (context, index, rindex) {
               return Container(
                   child: Image.network(
-                "http://10.0.2.2:8000/images/CarPictures/" +
+                "${ApiConfig.baseUrl}/images/CarPictures/" +
                     (controller.detaildata['image_car'][index]['imageName']
                         .toString()),
                 fit: BoxFit.fill,

--- a/lib/view/sell/forsell.dart
+++ b/lib/view/sell/forsell.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/detailesfoecaruserselected.dart';
 import 'package:car_x/view/sell/detailesfoecarsellselected.dart';
 
@@ -84,7 +86,7 @@ class forsell extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -130,7 +132,7 @@ class getallsellcarcontroller extends GetxController {
   var detaildata;
   Future getallsellcars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/getAllForSelling');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/getAllForSelling');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -141,7 +143,7 @@ class getallsellcarcontroller extends GetxController {
 
     if (status == 200) {
       car = data;
-      print(car);
+      if (kDebugMode) debugPrint(car);
     }
   }
 }

--- a/lib/view/sell/sold.dart
+++ b/lib/view/sell/sold.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/home/detailesfoecaruserselected.dart';
 import 'package:car_x/view/sell/detailesfoecarsoldselected.dart';
 
@@ -84,7 +86,7 @@ class sold extends StatelessWidget {
                                 itemBuilder: (context, index, rindex) {
                                   return Container(
                                       child: Image.network(
-                                    "http://10.0.2.2:8000/images/CarPictures/" +
+                                    "${ApiConfig.baseUrl}/images/CarPictures/" +
                                         (controller.imagecar[index]['imageName']
                                             .toString()),
                                     fit: BoxFit.cover,
@@ -130,7 +132,7 @@ class getallsoldcarcontroller extends GetxController {
   var detaildata;
   Future getallsoldcars() async {
     update();
-    var url = Uri.parse('http://10.0.2.2:8000/api/Car/getAllSoldCars');
+    var url = Uri.parse('${ApiConfig.baseUrl}/api/Car/getAllSoldCars');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -140,7 +142,7 @@ class getallsoldcarcontroller extends GetxController {
     data = json.decode(response.body);
 
     if (status == 200) {
-      print(data);
+      if (kDebugMode) debugPrint(data);
 
       if (data.toString().contains('no')) {
         car = data;

--- a/lib/view/workshop/conform.dart
+++ b/lib/view/workshop/conform.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/workshop/mapment.dart';
 import 'package:car_x/view/workshop/mentview.dart';
 import 'package:flutter/material.dart';
@@ -86,7 +88,7 @@ class getallconformcontroller extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("worktoken");
     getallconformconn();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -98,7 +100,7 @@ class getallconformcontroller extends GetxController {
   List requ = [];
   Future getallconformconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/WorkShop/Maintenance/getMyConfirmedRequest');
+        '${ApiConfig.baseUrl}/api/WorkShop/Maintenance/getMyConfirmedRequest');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -112,7 +114,7 @@ class getallconformcontroller extends GetxController {
         requ = data;
       }
 
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }

--- a/lib/view/workshop/mapment.dart
+++ b/lib/view/workshop/mapment.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:car_x/view/workshop/mentview.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
@@ -46,7 +47,7 @@ class MapsampleState extends State<Mapsample> {
 
     _center = LatLng(currentLocation.latitude, currentLocation.longitude);
 
-    print('center $_center');
+    if (kDebugMode) debugPrint('center $_center');
 
     _kGooglePlex = CameraPosition(
       target: _center,
@@ -120,7 +121,7 @@ class MapsampleState extends State<Mapsample> {
             _controller?.animateCamera(CameraUpdate.newLatLng(
               _center,
             ));
-            print(_center);
+            if (kDebugMode) debugPrint(_center);
           },
           label: Row(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/view/workshop/mentview.dart
+++ b/lib/view/workshop/mentview.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:car_x/config/api_config.dart';
 import 'package:car_x/view/workshop/conform.dart';
 import 'package:car_x/view/workshop/mapment.dart';
 import 'package:flutter/material.dart';
@@ -177,7 +179,7 @@ class getallmentcontroller extends GetxController {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     token = prefs.getString("worktoken");
     getallmentconn();
-    print(token);
+    if (kDebugMode) debugPrint(token);
     super.onInit();
   }
 
@@ -195,7 +197,7 @@ class getallmentcontroller extends GetxController {
   List req = [];
   Future getallmentconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/WorkShop/Maintenance/getAllMaintenanceRequest');
+        '${ApiConfig.baseUrl}/api/WorkShop/Maintenance/getAllMaintenanceRequest');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -204,14 +206,14 @@ class getallmentcontroller extends GetxController {
     var status = response.statusCode;
     data = json.decode(response.body);
     if (status == 200) {
-      print(data);
+      if (kDebugMode) debugPrint(data);
       update();
     }
   }
 
   Future confirmmentconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/WorkShop/Maintenance/confirmRequest/$id');
+        '${ApiConfig.baseUrl}/api/WorkShop/Maintenance/confirmRequest/$id');
     var response = await http.get(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -222,7 +224,7 @@ class getallmentcontroller extends GetxController {
 
   Future cancelementconn() async {
     var url = Uri.parse(
-        'http://10.0.2.2:8000/api/WorkShop/Maintenance/cancellationRequest/$id');
+        '${ApiConfig.baseUrl}/api/WorkShop/Maintenance/cancellationRequest/$id');
     var response = await http.put(url, headers: {
       'Authorization': 'Bearer $token',
       "Connection": "Keep-Alive",
@@ -231,7 +233,7 @@ class getallmentcontroller extends GetxController {
     var status = response.statusCode;
     data2 = json.decode(response.body);
     if (status == 200) {
-      print(data2);
+      if (kDebugMode) debugPrint(data2);
       update();
     }
   }


### PR DESCRIPTION
## Summary
- centralize API base URL in `ApiConfig`
- update signup connection to use the configurable base URL and debug logging
- update all pages to use `ApiConfig.baseUrl` and replace `print` calls with `debugPrint` guarded by `kDebugMode`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684891d44f5483218c5859b05af7dc5d